### PR TITLE
Updated logic for determining rotary encoder direction

### DIFF
--- a/Brixcer_Box/include/KnobControl.h
+++ b/Brixcer_Box/include/KnobControl.h
@@ -4,8 +4,7 @@ class KnobControl {
     int knobPinB;
     int buttonPin;
 
-    int prevPinARead;
-    int prevPinBRead;
+    int state;
 
     public:
         KnobControl(int knobPinA, int knobPinB, int buttonPin);

--- a/Brixcer_Box/src/KnobControl.cpp
+++ b/Brixcer_Box/src/KnobControl.cpp
@@ -1,6 +1,33 @@
 #include <Arduino.h>
 #include "KnobControl.h"
 
+enum position {
+    START     = 0,
+    START_CW  = 1,
+    START_CCW = 2,
+    MID       = 3,
+    END_CW    = 4,
+    END_CCW   = 5,
+};
+
+int CW_ROT  = 0x10;
+int CCW_ROT = 0xFFF0;
+
+const int transitions[6][4] = {
+    // Starting Position
+    { START,   START_CW,  START_CCW, START },
+    // First step in CW direction
+    { START,   START_CW,  START,     MID },
+    // First step in CCW direction
+    { START,   START,     START_CCW, MID },
+    // Middle Position
+    { MID,     END_CCW,   END_CW,    MID },
+    // Last step in CW direction
+    { CW_ROT,  START,     END_CW,    MID },
+    // Last step in CCW direction
+    { CCW_ROT, END_CCW,   START,     MID },
+};
+
 
 KnobControl::KnobControl(int knobPinA, int knobPinB, int buttonPin) {
     this->knobPinA = knobPinA;
@@ -10,29 +37,19 @@ KnobControl::KnobControl(int knobPinA, int knobPinB, int buttonPin) {
     pinMode(this->knobPinA, INPUT);
     pinMode(this->knobPinB, INPUT);
     pinMode(this->buttonPin, INPUT_PULLUP);
+
+    this->state = START;
 }
 
 int KnobControl::readKnobValues() {
-    int knobValues[2] = {digitalRead(knobPinA), digitalRead(knobPinB)};
+    // Grab state of input pins.
+    int pinstate = (digitalRead(knobPinB) << 1) | digitalRead(knobPinA);
 
-    // Check if this knob was the activated one
-    int spinDirection = 0;
-    if (prevPinARead != knobValues[0] || prevPinBRead != knobValues[1]) {
-        bool aChanged = prevPinARead != knobValues[0];
-        bool pinsAreEqual = knobValues[0] == knobValues[1];
+    // Determine new state from the pins and state table.
+    state = transitions[state & 0x7][pinstate];
 
-        if (aChanged && pinsAreEqual) {
-            spinDirection = -1;
-        }
-        if (aChanged && !pinsAreEqual) {
-            spinDirection = 1;
-        }
-
-        prevPinARead = knobValues[0];
-        prevPinBRead = knobValues[1];
-    }
-
-    return spinDirection;
+    // Return emit bits, ie the generated event.
+    return state >> 4;
 }
 
 int KnobControl::readButtonValue() {


### PR DESCRIPTION
# Description
## Problem
The amount of interrupt pins we wanted was more than the amount on most available microcontrollers. Additionally, the logic being used to determine direction of the rotary encoders was flimsy as there was no debouncing present in the code. This caused the readings to sometimes suggest that the encoder was being spun back and forth rapidly rather than in one direction.

## Solution
Using a state machine removes the need for debouncing as any odd readings from the rotary encoder will reset it to the starting position. Alongside this, the PR removes the need for interrupt pins as it adds polling to the main loop of the microcontroller. The reason for this is that the microcontroller really only has one job, which is to listen for rotations of the rotary encoder. Since it is the primary job of the microcontroller, there is no reason to add an interrupt since there will be no other actions being performed.

Fixes #34
