### PR TITLE
Rotation calculation improvements

### DIFF
--- a/Brixcer_Box/include/KnobControl.h
+++ b/Brixcer_Box/include/KnobControl.h
@@ -1,13 +1,20 @@
 class KnobControl {
 
+    // Interval of time to count the number of rotations
+    static const int ROTATION_COUNT_INTERVAL_MS = 200;
+
     int knobPinA;
     int knobPinB;
     int buttonPin;
 
     int state;
 
+    int rotationCounter;
+    unsigned long timeOfLastUpdate;
+
     public:
         KnobControl(int knobPinA, int knobPinB, int buttonPin);
         int readKnobValues();
+        int getNumberOfRotations();
         int readButtonValue();
 };

--- a/Brixcer_Box/src/KnobControl.cpp
+++ b/Brixcer_Box/src/KnobControl.cpp
@@ -10,8 +10,8 @@ enum position {
     END_CCW   = 5,
 };
 
-int CW_ROT  = 0x10;
-int CCW_ROT = 0xFFF0;
+int16_t CW_ROT  = 0x10;
+int16_t CCW_ROT = 0xFFF0;
 
 const int transitions[6][4] = {
     // Starting Position

--- a/Brixcer_Box/src/main.cpp
+++ b/Brixcer_Box/src/main.cpp
@@ -39,7 +39,7 @@ LedControl* leds = (LedControl*) malloc(sizeof(LedControl) * KnobCount);
 //MediaControl mediaControl(PlayPause, Previous, Next);
 
 // Define array for Serial input
-const int numChars = 33; // 32 chars + 1 for `\0`
+const int numChars = 33; // 32 chars + 1 for \0
 char receivedChars[numChars];
 
 // Define Serial interface
@@ -162,7 +162,7 @@ void buttonClick() {
 
 void knobPinTrigger() {
     for (int i = 0; i < KnobCount; i++) {
-        int value = knobs[i].readKnobValues();
+        int value = knobs[i].getNumberOfRotations();
         if (value != 0) {
             sendData(i, 0, value);
         }


### PR DESCRIPTION
# Description
## Problem
When a rotary encoder is spun, the resulting direction is immediately sent to the host machine. When this happens, the host machine will store a buffer of each spin (as there are typically many sent at the same time). The host machine then calls the volume changer logic on the operating system one instruction at a time. And since each instruction is equivalent to one rotation, multiple instructions need to be sent to the OS in order to perform the volume changes requested. The code to interface with the operating system is rather slow, meaning there can be quite a bit of latency between rotary encoder spins and the volume actually changing

## Solution
The rotary encoder spins are now grouped into 200ms intervals. This allows for sending one request that represents multiple spins rather than multiple request with one spin. This reduces the latency seen with the OS operations

Additionally, the bitwise operations for determining direction of rotation were modified slightly. When using boards with different underlying storage space for `int`, the bitwise logic would not always act the way intended. For example, with the Arduino Uno `int` represents `int16`, whereas `int` on a Teensy 3.2 is actually an `int32`. This meant the bitwise math of the Teensy did not properly account for the negative rotation direction because the beginning 16 bits remained as all 0s. The datatype used to store was changed to `int16` to allow for the math to continue to work regardless of board being used